### PR TITLE
require all questions to be answered

### DIFF
--- a/src/lib/components/ExerciseModal.svelte
+++ b/src/lib/components/ExerciseModal.svelte
@@ -18,9 +18,18 @@
 
 	// We've created a custom submit function to pass the response and close the modal.
 	function onFormSubmit(): void {
-		if ($modalStore[0].response) $modalStore[0].response(ratings);
-		ratings = new Map();		
-		modalStore.close();
+		const allRatingsFilled = questions.every((question) => ratings[question] !== 0);
+		console.log('allRatingsFilled', allRatingsFilled);
+		if (allRatingsFilled === false) {
+			alert('Please fill out all ratings before submitting.');
+			return;
+		}
+		else{
+			if ($modalStore[0].response) $modalStore[0].response(ratings);
+				ratings = new Map();		
+				modalStore.close();
+
+		}
 	}
 
 	// Base Classes


### PR DESCRIPTION
Applied a requirement that all of the ratings are supplied before submitting the workout feedback modal. 

Other known issues:
User can still hit cancel, or tap outside of the modal to close the modal without filling the 'form' which will cause errors down the line.